### PR TITLE
Fix compilation errors with Microsoft Visual C++ compiler

### DIFF
--- a/src/mpris2/mpris2.cpp
+++ b/src/mpris2/mpris2.cpp
@@ -28,7 +28,13 @@
 #include <QDir>
 #include <QAbstractItemModel>
 
+#ifdef _MSC_VER
+// fix absence of <unistd.h> and getpid()
+#include <Windows.h>
+#define getpid (unsigned )GetCurrentProcessId
+#else
 #include <unistd.h>
+#endif
 
 Mpris2::Mpris2(QObject* parent)
     : QObject(parent)

--- a/src/mpris2/mpris2.cpp
+++ b/src/mpris2/mpris2.cpp
@@ -31,7 +31,7 @@
 #ifdef _MSC_VER
 // fix absence of <unistd.h> and getpid()
 #include <Windows.h>
-#define getpid (unsigned )GetCurrentProcessId
+#define getpid (unsigned)GetCurrentProcessId
 #else
 #include <unistd.h>
 #endif

--- a/src/upnpControl.cpp
+++ b/src/upnpControl.cpp
@@ -93,7 +93,12 @@
 #include <QtAndroid>
 #endif
 
+#ifdef _MSC_VER
+// MSVC doesn't know __attribute__(...)
+int main(int argc, char *argv[])
+#else
 int __attribute__((visibility("default"))) main(int argc, char *argv[])
+#endif
 {
     qputenv("QT_GSTREAMER_USE_PLAYBIN_VOLUME", "true");
 


### PR DESCRIPTION
Just an example of how the fix would look like. Probably someone can fins better solutions, but I don't know... this works.

At least it starts:
![screenshot](https://puu.sh/vKyS6/0363cd5c3e.jpg)