### PR TITLE
Remove duplicate MimeType entry in the desktop file

### DIFF
--- a/org.kde.elisa.desktop
+++ b/org.kde.elisa.desktop
@@ -28,7 +28,6 @@ GenericName[uk]=Музичний програвач Elisa
 GenericName[x-test]=xxElisa Music Playerxx
 GenericName[zh_CN]=Elisa 音乐播放器
 Icon=elisa
-MimeType=
 Name=Elisa
 Name[ar]=إليسّا
 Name[ast]=Elisa


### PR DESCRIPTION
The duplicate MimeType entry causes issue for Fedora packaging because the desktop file is checked for conformity during this process. It fails because of the duplicate entry.